### PR TITLE
Improve XHTML support by emitting XHTML/HTML5 compatible line break tags

### DIFF
--- a/source/dmarkdown/markdown.d
+++ b/source/dmarkdown/markdown.d
@@ -754,8 +754,11 @@ private void writeMarkdownEscaped(R)(ref R dst, string ln, in LinkRef[string] li
 				} else {
 					if (ln.startsWith("<br>")) {
 						// always support line breaks, since we embed them here ourselves!
-						dst.put("<br>");
+						dst.put("<br/>");
 						ln = ln[4 .. $];
+					} else if(ln.startsWith("<br/>")) {
+						dst.put("<br/>");
+						ln = ln[5 .. $];
 					} else {
 						if( settings.flags & MarkdownFlags.noInlineHtml ) dst.put("&lt;");
 						else dst.put(ln[0]);
@@ -1273,7 +1276,7 @@ private struct Link {
 
 @safe unittest { // correct line breaks in restrictive mode
 	auto res = filterMarkdown("hello\nworld", MarkdownFlags.forumDefault);
-	assert(res == "<p>hello<br>world\n</p>\n", res);
+	assert(res == "<p>hello<br/>world\n</p>\n", res);
 }
 
 /*@safe unittest { // code blocks and blockquotes


### PR DESCRIPTION
This change builds upon my other pull request and changes the markdown processor to always emit "&lt;br/&gt;" instead of "&lt;br&gt;". This improves the XHTML compatibility while also staying compatible to HTML5 (although not to HTML4, but since the processor currently already emits "&lt;br/&gt;" under some circumstances, we don't actually loose compatibility with this change).

The related test was changed, too, and ran fine.